### PR TITLE
chore!: drop node 18, update dependencies and fix test

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,5 +17,5 @@ jobs:
   test:
     uses: voxpelli/ghatemplates/.github/workflows/test.yml@main
     with:
-      node-versions: '18,20,22,23'
+      node-versions: '20,22,24'
       os: 'ubuntu-latest,windows-latest'

--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -1,7 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "entry": [
-    "index.js",
     "index.d.ts"
   ],
   "ignore": [

--- a/lib/load-plugins.js
+++ b/lib/load-plugins.js
@@ -58,7 +58,7 @@ export function loadPlugins (processPlugin, options = {}) {
       throw new Error(`Failed to find plugin "${pluginName}" in "${cwd}"`, { cause });
     }
 
-    if (path.relative(cwd, pluginPath).startsWith('../')) {
+    if (path.relative(cwd, pluginPath).startsWith('..' + path.sep)) {
       throw new Error(`Path traversal detected for "${pluginName}", trying to load outside of "${cwd}": ${pluginPath}`);
     }
 

--- a/lib/load-plugins.js
+++ b/lib/load-plugins.js
@@ -9,7 +9,7 @@ import { importAbsolutePath } from './utils.js';
 /**
  * @typedef LoadPluginsOptions
  * @property {string|undefined} [cwd]
- * @property {ImportMeta} [meta]
+ * @property {Pick<ImportMeta, 'url'>} [meta]
  * @property {string|undefined} [prefix]
  */
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Pelle Wessman <pelle@kodfabrik.se> (http://kodfabrik.se/)",
   "license": "MIT",
   "engines": {
-    "node": ">=18.6.0"
+    "node": "^20.15.0 || >=22.2.0"
   },
   "type": "module",
   "exports": "./index.js",
@@ -49,7 +49,7 @@
     "@hapi/topo": "^6.0.2"
   },
   "devDependencies": {
-    "@types/node": "^18.19.86",
+    "@types/node": "^20.19.9",
     "@types/sinon": "^17.0.4",
     "@voxpelli/eslint-config": "^23.0.0",
     "@voxpelli/node-test-pretty-reporter": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -53,17 +53,17 @@
     "@types/sinon": "^17.0.4",
     "@voxpelli/eslint-config": "^23.0.0",
     "@voxpelli/node-test-pretty-reporter": "^1.1.2",
-    "@voxpelli/tsconfig": "^15.1.2",
+    "@voxpelli/tsconfig": "^16.0.0",
     "c8": "^10.1.3",
     "desm": "^1.3.1",
-    "eslint": "^9.23.0",
+    "eslint": "^9.32.0",
     "husky": "^9.1.7",
     "installed-check": "^9.3.0",
-    "knip": "^5.46.5",
-    "npm-run-all2": "^7.0.2",
-    "sinon": "^20.0.0",
+    "knip": "^5.62.0",
+    "npm-run-all2": "^8.0.4",
+    "sinon": "^21.0.0",
     "type-coverage": "^2.29.7",
-    "typescript": "~5.8.0",
+    "typescript": "~5.9.0",
     "validate-conventional-commit": "^1.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "clean": "run-p clean:*",
     "prepare": "husky",
     "prepublishOnly": "run-s build",
-    "test:node": "c8 --reporter=lcov --reporter text node --test --test-reporter=@voxpelli/node-test-pretty-reporter",
+    "test:node": "c8 --reporter=lcov --reporter text node --test",
     "test-ci": "run-s test:*",
     "test": "run-s check test:*"
   },
@@ -52,7 +52,6 @@
     "@types/node": "^20.19.9",
     "@types/sinon": "^17.0.4",
     "@voxpelli/eslint-config": "^23.0.0",
-    "@voxpelli/node-test-pretty-reporter": "^1.1.2",
     "@voxpelli/tsconfig": "^16.0.0",
     "c8": "^10.1.3",
     "desm": "^1.3.1",

--- a/test/plain-plugins.spec.js
+++ b/test/plain-plugins.spec.js
@@ -50,10 +50,17 @@ describe('Plain Plugins', () => {
          */
         (err) => {
           assert(err instanceof Error);
-          assert.strictEqual(err.message, 'Failed to load plugin "./../index.js"');
+          assert.strictEqual(
+            err.message,
+            'Failed to load plugin "./../index.js"'.replaceAll('/', path.sep)
+          );
 
           assert(err.cause instanceof Error);
-          assert.match(err.cause.message, /^Path traversal detected for "\.\/\.\.\/index\.js", trying to load outside of "/);
+          // eslint-disable-next-line security/detect-non-literal-regexp
+          assert.match(err.cause.message, new RegExp(
+            '^Path traversal detected for "\\./\\.\\./index\\.js", trying to load outside of "'
+              .replaceAll('/', path.sep === '\\' ? '\\\\' : '/')
+          ));
 
           return true;
         },

--- a/test/plain-plugins.spec.js
+++ b/test/plain-plugins.spec.js
@@ -36,41 +36,61 @@ describe('Plain Plugins', () => {
     });
 
     it('should throw on path traversal', async () => {
-      try {
-        await resolvePlainPlugins([
-          './traversal',
-        ], {
-          cwd: join(import.meta.url, '../test-fixtures/'),
-        });
-        assert.fail('Expected resolvePlainPlugins to fail');
-      } catch (err) {
-        assert(err instanceof Error);
-        assert.strictEqual(err.message, 'Failed to load plugin "./../index.js"');
-        assert(err.cause instanceof Error);
-        assert.match(err.cause.message, /^Path traversal detected for "\.\/\.\.\/index\.js", trying to load outside of "/);
-      }
+      await assert.rejects(
+        async () => {
+          await resolvePlainPlugins([
+            './traversal',
+          ], {
+            cwd: join(import.meta.url, '../test-fixtures/'),
+          });
+        },
+        /**
+         * @param {unknown} err
+         * @returns {true}
+         */
+        (err) => {
+          assert(err instanceof Error);
+          assert.strictEqual(err.message, 'Failed to load plugin "./../index.js"');
+
+          assert(err.cause instanceof Error);
+          assert.match(err.cause.message, /^Path traversal detected for "\.\/\.\.\/index\.js", trying to load outside of "/);
+
+          return true;
+        },
+        'Expected resolvePlainPlugins to fail'
+      );
     });
 
     it('should throw on circular dependencies', async () => {
-      try {
-        await resolvePlainPlugins([
-          './circular',
-        ], {
-          cwd: join(import.meta.url, '../test-fixtures/'),
-        });
-        assert.fail('Expected resolvePlainPlugins to fail');
-      } catch (err) {
-        assert(err instanceof Error);
-        assert.strictEqual(
-          err.message,
-          'Failed to add plugin "./circular/index.js"'.replaceAll('/', path.sep)
-        );
-        assert(err.cause instanceof Error);
-        assert.strictEqual(
-          err.cause.message,
-          'item added into group ./circular/index.js created a dependencies error'.replaceAll('/', path.sep)
-        );
-      }
+      await assert.rejects(
+        async () => {
+          await resolvePlainPlugins([
+            './circular',
+          ], {
+            cwd: join(import.meta.url, '../test-fixtures/'),
+          });
+        },
+        /**
+         * @param {unknown} err
+         * @returns {true}
+         */
+        (err) => {
+          assert(err instanceof Error);
+          assert.strictEqual(
+            err.message,
+            'Failed to add plugin "./circular/index.js"'.replaceAll('/', path.sep)
+          );
+
+          assert(err.cause instanceof Error);
+          assert.strictEqual(
+            err.cause.message,
+            'item added into group ./circular/index.js created a dependencies error'.replaceAll('/', path.sep)
+          );
+
+          return true;
+        },
+        'Expected resolvePlainPlugins to fail'
+      );
     });
 
     it('should support import.meta in place of cwd', async () => {
@@ -87,20 +107,29 @@ describe('Plain Plugins', () => {
     });
 
     it('should throw if both import.meta and cwd has been given', async () => {
-      try {
-        await resolvePlainPlugins([
-          './test-dependency',
-        ], {
-          cwd: join(import.meta.url, '../test-fixtures/'),
-          meta: {
-            url: (new URL('../test-fixtures/index.js', import.meta.url)).toString(),
-          },
-        });
-        assert.fail('Expected resolvePlainPlugins to fail');
-      } catch (err) {
-        assert(err instanceof Error);
-        assert.strictEqual(err.message, 'Can not provide both cwd and meta at once');
-      }
+      await assert.rejects(
+        async () => {
+          await resolvePlainPlugins([
+            './test-dependency',
+          ], {
+            cwd: join(import.meta.url, '../test-fixtures/'),
+            meta: {
+              url: (new URL('../test-fixtures/index.js', import.meta.url)).toString(),
+            },
+          });
+        },
+        /**
+         * @param {unknown} err
+         * @returns {true}
+         */
+        (err) => {
+          assert(err instanceof Error);
+          assert.strictEqual(err.message, 'Can not provide both cwd and meta at once');
+
+          return true;
+        },
+        'Expected resolvePlainPlugins to fail'
+      );
     });
 
     // TODO: Test prefix option

--- a/test/plain-plugins.spec.js
+++ b/test/plain-plugins.spec.js
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import path from 'node:path';
 
 import { join } from 'desm';
 
@@ -25,7 +26,7 @@ describe('Plain Plugins', () => {
         },
         {
           dependencies: [
-            './test-dependency/test-dependency-2.js',
+            './test-dependency/test-dependency-2.js'.replaceAll('/', path.sep),
           ],
           foo: 'bar',
           name: 'test-dependency',
@@ -60,9 +61,15 @@ describe('Plain Plugins', () => {
         assert.fail('Expected resolvePlainPlugins to fail');
       } catch (err) {
         assert(err instanceof Error);
-        assert.strictEqual(err.message, 'Failed to add plugin "./circular/index.js"');
+        assert.strictEqual(
+          err.message,
+          'Failed to add plugin "./circular/index.js"'.replaceAll('/', path.sep)
+        );
         assert(err.cause instanceof Error);
-        assert.strictEqual(err.cause.message, 'item added into group ./circular/index.js created a dependencies error');
+        assert.strictEqual(
+          err.cause.message,
+          'item added into group ./circular/index.js created a dependencies error'.replaceAll('/', path.sep)
+        );
       }
     });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@voxpelli/tsconfig/node18.json",
+  "extends": "@voxpelli/tsconfig/node20.json",
   "files": [
     "index.js"
   ],


### PR DESCRIPTION
This pull request includes updates to improve compatibility, enhance error handling, and modernize dependencies. Key changes involve updating Node.js version requirements, refining error handling in plugin loading, and improving test cases for better coverage and reliability.

### Compatibility Updates:
* [`.github/workflows/nodejs.yml`](diffhunk://#diff-e98936aa52a6dd7416e4296e9628456227d834f7245967383fd9ff80fd985dadL20-R20): Updated Node.js versions in the test workflow to `20,22,24`, removing older versions to align with updated compatibility requirements.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L16-R16): Updated the Node.js engine requirement to `^20.15.0 || >=22.2.0` to reflect the new minimum supported versions.

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L44-R65): Upgraded several dependencies and devDependencies, including `@types/node`, `eslint`, `knip`, and `typescript`, among others, to their latest versions. Removed `@voxpelli/node-test-pretty-reporter` and other unused dependencies.

### Code Enhancements:
* [`lib/load-plugins.js`](diffhunk://#diff-86ecb36d60009a043f2dbfd6b2d43a3e40ba74393391c5bbfc4f162a22c6f48bL12-R12): Enhanced path traversal detection by using `path.sep` for cross-platform compatibility. Updated the `meta` property type to `Pick<ImportMeta, 'url'>` for stricter type checking. [[1]](diffhunk://#diff-86ecb36d60009a043f2dbfd6b2d43a3e40ba74393391c5bbfc4f162a22c6f48bL12-R12) [[2]](diffhunk://#diff-86ecb36d60009a043f2dbfd6b2d43a3e40ba74393391c5bbfc4f162a22c6f48bL61-R61)

### Test Improvements:
* [`test/plain-plugins.spec.js`](diffhunk://#diff-f1d43f777963b447f556e99b00130b05e7fed42a2b8c6ef26a699eccb6caf72cL28-R29): Improved test cases for error scenarios such as path traversal, circular dependencies, and conflicting options (`cwd` and `meta`). Added `path.sep` handling for platform-independent path assertions. Replaced manual error handling with `assert.rejects` for cleaner and more reliable test assertions. [[1]](diffhunk://#diff-f1d43f777963b447f556e99b00130b05e7fed42a2b8c6ef26a699eccb6caf72cL28-R29) [[2]](diffhunk://#diff-f1d43f777963b447f556e99b00130b05e7fed42a2b8c6ef26a699eccb6caf72cL38-R100) [[3]](diffhunk://#diff-f1d43f777963b447f556e99b00130b05e7fed42a2b8c6ef26a699eccb6caf72cL83-R118) [[4]](diffhunk://#diff-f1d43f777963b447f556e99b00130b05e7fed42a2b8c6ef26a699eccb6caf72cL92-R139)
